### PR TITLE
The references for font-awesone are only needed for testing

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,8 @@
 import { configure } from '@storybook/react';
+import 'font-awesome/css/font-awesome.min.css';
 
 const req = require.context("../stories", true, /\.storybook\.tsx$/);
+
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@osu-cass/react-advanced-filter",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osu-cass/react-advanced-filter",
-  "version": "1.0.0-beta",
+  "version": "1.0.1-beta",
   "description": "A component that filters item results for Smarter Balanced.",
   "main": "build/index",
   "files": [
@@ -9,7 +9,7 @@
   "types": "./build/index.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/jest",
-    "start": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "build": "node_modules/.bin/tsc && cp -r ./src/styles/ ./build/styles/ && cp ./src/index.d.ts ./build/"
   },

--- a/src/Filter/AdvancedFilter.tsx
+++ b/src/Filter/AdvancedFilter.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { AdvancedFilterCategory, AdvancedFilterOption, OptionType } from './AdvancedFilterModel';
 import "../styles/AdvancedFilter.css";
-import "font-awesome/css/font-awesome.min.css";
 
 export interface Props extends AdvancedFilterCategory { 
     selectedHandler: (data?: AdvancedFilterOption) => void;

--- a/src/Filter/AdvancedFilterContainer.tsx
+++ b/src/Filter/AdvancedFilterContainer.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { AdvancedFilterOption, OptionType, AdvancedFilterCategory, AdvancedFilters } from './AdvancedFilterModel';
 import { AdvancedFilter } from './AdvancedFilter';
 import "../styles/AdvancedFilter.css";
-import "font-awesome/css/font-awesome.min.css";
 
 export interface Props {
     filterOptions: AdvancedFilterCategory[];


### PR DESCRIPTION
The references to font-awesome would cause the AP_ScoringGuide webpack compilation to fail.  Removing the references to  font-awesome and adding them to only the test file fixed this issue.